### PR TITLE
fix: stripe endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "storybook": "storybook dev -p 6006",
+    "stripe:local": "stripe listen --forward-to localhost:3000/api/webhooks/stripe",
     "build-storybook": "storybook build"
   },
   "dependencies": {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { authMiddleware } from "@clerk/nextjs";
 
 export default authMiddleware({
-  publicRoutes: ["/", "/register"],
+  publicRoutes: ["/", "/register", "/api/webhooks/stripe"],
 });
 
 export const config = {

--- a/src/pages/api/addTokens.ts
+++ b/src/pages/api/addTokens.ts
@@ -1,13 +1,13 @@
 import stripeInit from "stripe";
 import { getAuth } from "@clerk/nextjs/server";
 
-const stripe = stripeInit(process.env.STRIPE_SECRET_KEY);
+const stripe = new stripeInit(process.env.STRIPE_SECRET_KEY as string);
 
 export default async function handler(req, res) {
   const { userId } = getAuth(req);
   const lineItems = [
     {
-      price: process.env.STRIPE_PRODUCT_PRICE_ID,
+      price: process.env.STRIPE_TEST_PRODUCT_PAGE,
       quantity: 1,
     },
   ];


### PR DESCRIPTION
The issues you had:

- Incorrect environment variable name
- Issues with NextJS automatically patching and parsing the request (`Request.text()` would have worked with Express/Remix, but Next decided otherwise...)
- Confusing Webhooks with regular routes: Webhook should receive the userID from metadata, not from request headers/cookies like a regular route with Clerk
  - This confusion was causing issues both in the file itself, and in the middleware